### PR TITLE
fix: add headers to crates query

### DIFF
--- a/pkg/feeds/crates/crates.go
+++ b/pkg/feeds/crates/crates.go
@@ -41,7 +41,16 @@ func fetchPackages(baseURL string) ([]*Package, error) {
 	if err != nil {
 		return nil, err
 	}
-	resp, err := httpClient.Get(pkgURL)
+
+	req, err := http.NewRequest("GET", pkgURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// set headers
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "package-feeds")
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Otherwise we are getting denied from cloudfront